### PR TITLE
Rename makefile to fix compile issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,6 @@ CFLAGS=-Wall -Wextra -pedantic -std=c99 -O3 -IInclude
 
 main: main.c
 	$(CC) $(CFLAGS) main.c Include/functions.c -o main
-	
+
 run:
 	./main


### PR DESCRIPTION
Trying to compile currently does not work:
![image](https://user-images.githubusercontent.com/34138240/149658230-40e01872-b1e0-43e0-aefa-3e1b0ec42950.png)
With this change, it's now compilable:
![image](https://user-images.githubusercontent.com/34138240/149658264-38ef6b4a-caeb-4f8c-a1e4-671232a75a64.png)
